### PR TITLE
Suppress alarms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,6 @@
          xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
 
-    <repositories>
-        <repository>
-            <id>customer-release-repo</id>
-            <url>https://nexus.curity.se/nexus/content/repositories/customer-release-repo</url>
-            <snapshots><enabled>false</enabled></snapshots>
-        </repository>
-    </repositories>
-
     <groupId>se.curity.identityserver</groupId>
     <artifactId>identityserver.plugins.data.access.json</artifactId>
     <version>2.2.2</version>
@@ -56,7 +48,7 @@
         <dependency>
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
-            <version>2.3.1</version>
+            <version>5.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>se.curity.identityserver</groupId>
     <artifactId>identityserver.plugins.data.access.json</artifactId>
-    <version>2.2.2</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
     <name>JSON Data Access Plugin</name>
 

--- a/src/main/java/io/curity/identityserver/plugin/data/access/json/JsonAttributeDataAccessProvider.java
+++ b/src/main/java/io/curity/identityserver/plugin/data/access/json/JsonAttributeDataAccessProvider.java
@@ -26,6 +26,7 @@ import io.curity.identityserver.plugin.data.access.json.parameter.StaticMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.curity.identityserver.sdk.Nullable;
+import se.curity.identityserver.sdk.ThreadSafe;
 import se.curity.identityserver.sdk.attribute.AttributeName;
 import se.curity.identityserver.sdk.attribute.AttributeTableView;
 import se.curity.identityserver.sdk.attribute.Attributes;
@@ -49,11 +50,11 @@ import static io.curity.identityserver.plugin.data.access.json.CollectionUtils.t
 import static io.curity.identityserver.plugin.data.access.json.CollectionUtils.toMultiMap;
 import static se.curity.identityserver.sdk.http.HttpResponse.asString;
 
-public class JsonAttributeDataAccessProvider implements AttributeDataAccessProvider
+public class JsonAttributeDataAccessProvider implements AttributeDataAccessProvider, ThreadSafe
 {
     private static final String SUBJECT_PLACEHOLDER = ":subject";
 
-    private final static Logger _logger = LoggerFactory.getLogger(JsonAttributeDataAccessProvider.class);
+    private static final Logger _logger = LoggerFactory.getLogger(JsonAttributeDataAccessProvider.class);
 
     private final AttributesConfiguration _configuration;
     private final WebServiceClient _webServiceClient;

--- a/src/main/java/io/curity/identityserver/plugin/data/access/json/JsonCredentialDataAccessProvider.java
+++ b/src/main/java/io/curity/identityserver/plugin/data/access/json/JsonCredentialDataAccessProvider.java
@@ -45,6 +45,7 @@ import static io.curity.identityserver.plugin.data.access.json.CollectionUtils.t
 import static io.curity.identityserver.plugin.data.access.json.WebUtils.isSuccessfulJsonResponse;
 import static io.curity.identityserver.plugin.data.access.json.WebUtils.urlEncode;
 import static io.curity.identityserver.plugin.data.access.json.WebUtils.urlEncodedFormData;
+import static se.curity.identityserver.sdk.alarm.AlarmType.EXTERNAL_SERVICE_FAILED_AUTHENTICATION;
 
 public class JsonCredentialDataAccessProvider implements CredentialDataAccessProvider, ThreadSafe
 {
@@ -217,18 +218,21 @@ public class JsonCredentialDataAccessProvider implements CredentialDataAccessPro
         {
             case POST_AS_JSON:
                 return webServiceClient.request()
+                        .withoutAlarm(EXTERNAL_SERVICE_FAILED_AUTHENTICATION)
                         .contentType(JsonClientRequestContentType.APPLICATION_JSON.toString())
                         .accept(JsonClientRequestContentType.APPLICATION_JSON.toString())
                         .body(HttpRequest.fromString(_json.toJson(requestParameterMap), StandardCharsets.UTF_8))
                         .method("POST");
             case POST_AS_URLENCODED_FORMDATA:
                 return webServiceClient.request()
+                        .withoutAlarm(EXTERNAL_SERVICE_FAILED_AUTHENTICATION)
                         .contentType(JsonClientRequestContentType.APPLICATION_WWW_FORM_URLENCODED.toString())
                         .accept(JsonClientRequestContentType.APPLICATION_JSON.toString())
                         .body(HttpRequest.fromString(urlEncodedFormData(requestParameterMap), StandardCharsets.ISO_8859_1))
                         .method("POST");
             case GET_AS_QUERYSTRING:
                 return webServiceClient.withQueries(toMultiMap(requestParameterMap)).request()
+                        .withoutAlarm(EXTERNAL_SERVICE_FAILED_AUTHENTICATION)
                         .accept(JsonClientRequestContentType.APPLICATION_JSON.toString())
                         .method("GET");
             default:

--- a/src/main/java/io/curity/identityserver/plugin/data/access/json/JsonCredentialDataAccessProvider.java
+++ b/src/main/java/io/curity/identityserver/plugin/data/access/json/JsonCredentialDataAccessProvider.java
@@ -23,6 +23,7 @@ import io.curity.identityserver.plugin.data.access.json.config.JsonDataAccessPro
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.curity.identityserver.sdk.Nullable;
+import se.curity.identityserver.sdk.ThreadSafe;
 import se.curity.identityserver.sdk.attribute.AccountAttributes;
 import se.curity.identityserver.sdk.attribute.AttributeName;
 import se.curity.identityserver.sdk.attribute.Attributes;
@@ -44,7 +45,7 @@ import static io.curity.identityserver.plugin.data.access.json.WebUtils.isSucces
 import static io.curity.identityserver.plugin.data.access.json.WebUtils.urlEncode;
 import static io.curity.identityserver.plugin.data.access.json.WebUtils.urlEncodedFormData;
 
-public class JsonCredentialDataAccessProvider implements CredentialDataAccessProvider
+public class JsonCredentialDataAccessProvider implements CredentialDataAccessProvider, ThreadSafe
 {
     private static final String SUBJECT_PLACEHOLDER = ":subject";
     private static final String PASSWORD_PLACEHOLDER = ":password";

--- a/src/main/java/io/curity/identityserver/plugin/data/access/json/WebUtils.java
+++ b/src/main/java/io/curity/identityserver/plugin/data/access/json/WebUtils.java
@@ -92,7 +92,7 @@ final class WebUtils
         {
             Optional<String> jsonContentType = contentTypes.stream().filter(WebUtils::isJson).findFirst();
 
-            if (!jsonContentType.isPresent())
+            if (!jsonContentType.isPresent() && _logger.isDebugEnabled())
             {
                 _logger.debug("JSON DataSource provided an unexpected Content-Type: '{}', " +
                         "will attempt to parse the response as JSON", String.join(", ", contentTypes));

--- a/src/main/java/io/curity/identityserver/plugin/descriptor/JsonDataAccessPluginDescriptor.java
+++ b/src/main/java/io/curity/identityserver/plugin/descriptor/JsonDataAccessPluginDescriptor.java
@@ -21,12 +21,12 @@ import io.curity.identityserver.plugin.data.access.json.JsonCredentialDataAccess
 import io.curity.identityserver.plugin.data.access.json.config.JsonDataAccessProviderConfiguration;
 import se.curity.identityserver.sdk.Nullable;
 import se.curity.identityserver.sdk.config.Configuration;
-import se.curity.identityserver.sdk.plugin.descriptor.DataAccessProviderPluginDescriptor;
 import se.curity.identityserver.sdk.datasource.AttributeDataAccessProvider;
 import se.curity.identityserver.sdk.datasource.CredentialDataAccessProvider;
+import se.curity.identityserver.sdk.plugin.descriptor.DataAccessProviderPluginDescriptor;
 
 @SuppressWarnings("unused")
-public class JsonDataAccessPluginDescriptor implements DataAccessProviderPluginDescriptor
+public class JsonDataAccessPluginDescriptor implements DataAccessProviderPluginDescriptor<Configuration>
 {
     @Override
     public String getPluginImplementationType()


### PR DESCRIPTION
Suppressing failed-authentication alarms on credential verification.

Also:
* Adding missing Configuration generic to JsonDataAccessPluginDescriptor
* only join strings if debug logging is enabled
* Marking DAPs as ThreadSafe
* Pass error from JSON data source to OAuth client which uses ROPC
* Bumping version